### PR TITLE
fix: avoid breaking tekton reconciliation

### DIFF
--- a/pkg/trace/tkn_pipelinerun_handler.go
+++ b/pkg/trace/tkn_pipelinerun_handler.go
@@ -78,6 +78,12 @@ func (h *TektonPipelineRunHandler) handlePipelineRun(pr *tknv1beta1.PipelineRun)
 		pr.Annotations = make(map[string]string)
 	}
 
+	if _, ok := pr.Labels["tekton.dev/pipeline"]; !ok {
+		// let's wait for the tekton controller to finish the PR reconciliation before patching it
+		// to avoid reconciliation failure (because of PR update failure), and the creation of multiple TR
+		return nil
+	}
+
 	span, err := h.getSpanFor(pr)
 	if errors.Is(err, ErrEventTraceNotFound) {
 		return nil


### PR DESCRIPTION
on old tekton v0.11.3 (used in jx v2), the pipelinerun reconciliation might fail because the tekton controller can't update the pipelinerun, because it has been changed (by our patching operation).
this is turn result in multiple taskruns being created (1 for each reconciliation attempt).

the "fix" is to wait until the initial reconciliation is finished, which is after the tekton controller has updated the PR labels, adding the `tekton.dev/pipeline` label.
which is why here we are now waiting until this label is present before handling the PR.