### PR TITLE
fix: avoid breaking lighthouse job creation

### DIFF
--- a/pkg/trace/lh_job_handler.go
+++ b/pkg/trace/lh_job_handler.go
@@ -79,6 +79,12 @@ func (h *LighthouseJobHandler) handleLighthouseJob(job *lhv1alpha1.LighthouseJob
 		job.Annotations = make(map[string]string)
 	}
 
+	if job.Status.State == "" {
+		// let's wait for lighthouse to finish the job creation before patching it
+		// to avoid creation failure (because of job status update failure), and "non-triggered" pipelines
+		return nil
+	}
+
 	span, eventTrace, err := h.getSpanFor(job)
 	if errors.Is(err, ErrEventTraceNotFound) {
 		return nil


### PR DESCRIPTION
similar as #2 but for lighthouse

lighthouse creates its jobs in 2 steps:
- for the job with its spec
- and then it updates the status to set the initial state ("triggered")

if we patch the job in the middle of these 2 steps, the status update will fail, and the job creation will fail, and the pipeline won't be triggered

the fix is to wait until the state is defined in the status before patching the job